### PR TITLE
Include IEEE P3109 dtypes [moved to https://github.com/jax-ml/ml_dtypes/pull/122]

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,12 +1,12 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0
+    rev: v4.5.0
     hooks:
       - id: end-of-file-fixer
       - id: trailing-whitespace
       - id: debug-statements
   - repo: https://github.com/google/pyink
-    rev: 23.3.1
+    rev: 23.10.0
     hooks:
       - id: pyink
         language_version: python3.9

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@
   * `float8_e4m3fnuz`
   * `float8_e5m2`
   * `float8_e5m2fnuz`
+  * `float8_p3109_p<p>`
 - `int4` and `uint4`: low precision integer types.
 
 See below for specifications of these number formats.
@@ -106,6 +107,20 @@ This type has the following characteristics:
  * infinities: Not supported
  * NaNs: Supported with sign bit set to 1, exponent bits and mantissa bits set to all 0s - `0b10000000`
  * denormals when exponent is 0
+
+### float8_p3109_p<p>
+
+These types represent the types under discussion in IEEE working group P3109,
+"Arithmetic Formats for Machine Learning ", parameterized by precision $p$.
+
+These type has the following characteristics:
+ * Precision $p$: $2 < p < 6$
+ * Exponent bits, E: $8-p$
+ * Exponent bias: 2 ^ (E-1)
+ * Infinities: +Inf, -Inf
+ * No negative zero
+ * Single NaN in the -0 position: `0b10000000` == `0x80`
+ * Denormals when exponent is 0
 
 ## `int4` and `uint4`
 

--- a/ml_dtypes/__init__.py
+++ b/ml_dtypes/__init__.py
@@ -12,19 +12,22 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = '0.3.1'  # Keep in sync with pyproject.toml:version
+__version__ = "0.3.1"  # Keep in sync with pyproject.toml:version
 __all__ = [
-    '__version__',
-    'bfloat16',
-    'finfo',
-    'float8_e4m3b11fnuz',
-    'float8_e4m3fn',
-    'float8_e4m3fnuz',
-    'float8_e5m2',
-    'float8_e5m2fnuz',
-    'iinfo',
-    'int4',
-    'uint4',
+    "__version__",
+    "bfloat16",
+    "finfo",
+    "float8_e4m3b11fnuz",
+    "float8_e4m3fn",
+    "float8_e4m3fnuz",
+    "float8_e5m2",
+    "float8_e5m2fnuz",
+    "float8_p3109_p3",
+    "float8_p3109_p4",
+    "float8_p3109_p5",
+    "iinfo",
+    "int4",
+    "uint4",
 ]
 
 from typing import Type
@@ -37,6 +40,9 @@ from ml_dtypes._ml_dtypes_ext import float8_e4m3fn
 from ml_dtypes._ml_dtypes_ext import float8_e4m3fnuz
 from ml_dtypes._ml_dtypes_ext import float8_e5m2
 from ml_dtypes._ml_dtypes_ext import float8_e5m2fnuz
+from ml_dtypes._ml_dtypes_ext import float8_p3109_p3
+from ml_dtypes._ml_dtypes_ext import float8_p3109_p4
+from ml_dtypes._ml_dtypes_ext import float8_p3109_p5
 from ml_dtypes._ml_dtypes_ext import int4
 from ml_dtypes._ml_dtypes_ext import uint4
 import numpy as np
@@ -47,6 +53,9 @@ float8_e4m3fn: Type[np.generic]
 float8_e4m3fnuz: Type[np.generic]
 float8_e5m2: Type[np.generic]
 float8_e5m2fnuz: Type[np.generic]
+float8_p3109_p3: Type[np.generic]
+float8_p3109_p4: Type[np.generic]
+float8_p3109_p5: Type[np.generic]
 int4: Type[np.generic]
 uint4: Type[np.generic]
 

--- a/ml_dtypes/_finfo.py
+++ b/ml_dtypes/_finfo.py
@@ -486,77 +486,37 @@ class finfo(np.finfo):  # pylint: disable=invalid-name,missing-class-docstring
     # pylint: enable=protected-access
     return obj
 
-  @staticmethod
-  def _float8_p3109_p3_finfo():
-    return finfo._float8_p3109_p_finfo(3)
-
-  @staticmethod
-  def _float8_p3109_p4_finfo():
-    return finfo._float8_p3109_p_finfo(4)
-
-  @staticmethod
-  def _float8_p3109_p5_finfo():
-    return finfo._float8_p3109_p_finfo(5)
-
   def __new__(cls, dtype):
-    if (
-        isinstance(dtype, str)
-        and dtype == "bfloat16"
-        or dtype == _bfloat16_dtype
-    ):
-      if _bfloat16_dtype not in cls._finfo_cache:
-        cls._finfo_cache[_bfloat16_dtype] = cls._bfloat16_finfo()
-      return cls._finfo_cache[_bfloat16_dtype]
-    if (
-        isinstance(dtype, str)
-        and dtype == "float8_e4m3b11fnuz"
-        or dtype == _float8_e4m3b11fnuz_dtype
-    ):
-      if _float8_e4m3b11fnuz_dtype not in cls._finfo_cache:
-        cls._finfo_cache[_float8_e4m3b11fnuz_dtype] = (
-            cls._float8_e4m3b11fnuz_finfo()
-        )
-      return cls._finfo_cache[_float8_e4m3b11fnuz_dtype]
-    if (
-        isinstance(dtype, str)
-        and dtype == "float8_e4m3fn"
-        or dtype == _float8_e4m3fn_dtype
-    ):
-      if _float8_e4m3fn_dtype not in cls._finfo_cache:
-        cls._finfo_cache[_float8_e4m3fn_dtype] = cls._float8_e4m3fn_finfo()
-      return cls._finfo_cache[_float8_e4m3fn_dtype]
-    if (
-        isinstance(dtype, str)
-        and dtype == "float8_e4m3fnuz"
-        or dtype == _float8_e4m3fnuz_dtype
-    ):
-      if _float8_e4m3fnuz_dtype not in cls._finfo_cache:
-        cls._finfo_cache[_float8_e4m3fnuz_dtype] = cls._float8_e4m3fnuz_finfo()
-      return cls._finfo_cache[_float8_e4m3fnuz_dtype]
-    if (
-        isinstance(dtype, str)
-        and dtype == "float8_e5m2"
-        or dtype == _float8_e5m2_dtype
-    ):
-      if _float8_e5m2_dtype not in cls._finfo_cache:
-        cls._finfo_cache[_float8_e5m2_dtype] = cls._float8_e5m2_finfo()
-      return cls._finfo_cache[_float8_e5m2_dtype]
-    if (
-        isinstance(dtype, str)
-        and dtype == "float8_e5m2fnuz"
-        or dtype == _float8_e5m2fnuz_dtype
-    ):
-      if _float8_e5m2fnuz_dtype not in cls._finfo_cache:
-        cls._finfo_cache[_float8_e5m2fnuz_dtype] = cls._float8_e5m2fnuz_finfo()
-      return cls._finfo_cache[_float8_e5m2fnuz_dtype]
-    for type_str, test_dtype, finfo in (
-        ("float8_p3109_p3", _float8_p3109_p3_dtype, cls._float8_p3109_p3_finfo),
-        ("float8_p3109_p4", _float8_p3109_p4_dtype, cls._float8_p3109_p4_finfo),
-        ("float8_p3109_p5", _float8_p3109_p5_dtype, cls._float8_p3109_p5_finfo),
+    for type_str, test_dtype, constructor in (
+        ("bfloat16", _bfloat16_dtype, cls._bfloat16_finfo),
+        (
+            "float8_e4m3b11fnuz",
+            _float8_e4m3b11fnuz_dtype,
+            cls._float8_e4m3b11fnuz_finfo,
+        ),
+        ("float8_e4m3fn", _float8_e4m3fn_dtype, cls._float8_e4m3fn_finfo),
+        ("float8_e4m3fnuz", _float8_e4m3fnuz_dtype, cls._float8_e4m3fnuz_finfo),
+        ("float8_e5m2", _float8_e5m2_dtype, cls._float8_e5m2_finfo),
+        ("float8_e5m2fnuz", _float8_e5m2fnuz_dtype, cls._float8_e5m2fnuz_finfo),
+        (
+            "float8_p3109_p3",
+            _float8_p3109_p3_dtype,
+            lambda: cls._float8_p3109_p_finfo(3),
+        ),
+        (
+            "float8_p3109_p4",
+            _float8_p3109_p4_dtype,
+            lambda: cls._float8_p3109_p_finfo(4),
+        ),
+        (
+            "float8_p3109_p5",
+            _float8_p3109_p5_dtype,
+            lambda: cls._float8_p3109_p_finfo(5),
+        ),
     ):
       if isinstance(dtype, str) and dtype == type_str or dtype == test_dtype:
         if test_dtype not in cls._finfo_cache:
-          cls._finfo_cache[test_dtype] = finfo()
+          cls._finfo_cache[test_dtype] = constructor()
         return cls._finfo_cache[test_dtype]
 
     return super().__new__(cls, dtype)

--- a/ml_dtypes/_finfo.py
+++ b/ml_dtypes/_finfo.py
@@ -38,6 +38,21 @@ _float8_p3109_p3_dtype = np.dtype(float8_p3109_p3)
 _float8_p3109_p4_dtype = np.dtype(float8_p3109_p4)
 _float8_p3109_p5_dtype = np.dtype(float8_p3109_p5)
 
+_name_to_dtype = {
+    dtype.name: dtype
+    for dtype in (
+        _bfloat16_dtype,
+        _float8_e4m3b11fnuz_dtype,
+        _float8_e4m3fn_dtype,
+        _float8_e4m3fnuz_dtype,
+        _float8_e5m2_dtype,
+        _float8_e5m2fnuz_dtype,
+        _float8_p3109_p3_dtype,
+        _float8_p3109_p4_dtype,
+        _float8_p3109_p5_dtype,
+    )
+}
+
 
 class _Bfloat16MachArLike:
 
@@ -487,36 +502,20 @@ class finfo(np.finfo):  # pylint: disable=invalid-name,missing-class-docstring
     return obj
 
   def __new__(cls, dtype):
-    for type_str, test_dtype, constructor in (
-        ("bfloat16", _bfloat16_dtype, cls._bfloat16_finfo),
-        (
-            "float8_e4m3b11fnuz",
-            _float8_e4m3b11fnuz_dtype,
-            cls._float8_e4m3b11fnuz_finfo,
-        ),
-        ("float8_e4m3fn", _float8_e4m3fn_dtype, cls._float8_e4m3fn_finfo),
-        ("float8_e4m3fnuz", _float8_e4m3fnuz_dtype, cls._float8_e4m3fnuz_finfo),
-        ("float8_e5m2", _float8_e5m2_dtype, cls._float8_e5m2_finfo),
-        ("float8_e5m2fnuz", _float8_e5m2fnuz_dtype, cls._float8_e5m2fnuz_finfo),
-        (
-            "float8_p3109_p3",
-            _float8_p3109_p3_dtype,
-            lambda: cls._float8_p3109_p_finfo(3),
-        ),
-        (
-            "float8_p3109_p4",
-            _float8_p3109_p4_dtype,
-            lambda: cls._float8_p3109_p_finfo(4),
-        ),
-        (
-            "float8_p3109_p5",
-            _float8_p3109_p5_dtype,
-            lambda: cls._float8_p3109_p_finfo(5),
-        ),
+    for ty, constructor in (
+        (_bfloat16_dtype, cls._bfloat16_finfo),
+        (_float8_e4m3b11fnuz_dtype, cls._float8_e4m3b11fnuz_finfo),
+        (_float8_e4m3fn_dtype, cls._float8_e4m3fn_finfo),
+        (_float8_e4m3fnuz_dtype, cls._float8_e4m3fnuz_finfo),
+        (_float8_e5m2_dtype, cls._float8_e5m2_finfo),
+        (_float8_e5m2fnuz_dtype, cls._float8_e5m2fnuz_finfo),
+        (_float8_p3109_p3_dtype, lambda: cls._float8_p3109_p_finfo(3)),
+        (_float8_p3109_p4_dtype, lambda: cls._float8_p3109_p_finfo(4)),
+        (_float8_p3109_p5_dtype, lambda: cls._float8_p3109_p_finfo(5)),
     ):
-      if isinstance(dtype, str) and dtype == type_str or dtype == test_dtype:
-        if test_dtype not in cls._finfo_cache:
-          cls._finfo_cache[test_dtype] = constructor()
-        return cls._finfo_cache[test_dtype]
+      if isinstance(dtype, str) and dtype == ty.name or dtype == ty:
+        if ty not in cls._finfo_cache:
+          cls._finfo_cache[ty] = constructor()
+        return cls._finfo_cache[ty]
 
     return super().__new__(cls, dtype)

--- a/ml_dtypes/_finfo.py
+++ b/ml_dtypes/_finfo.py
@@ -22,6 +22,10 @@ from ml_dtypes._ml_dtypes_ext import float8_e4m3fn
 from ml_dtypes._ml_dtypes_ext import float8_e4m3fnuz
 from ml_dtypes._ml_dtypes_ext import float8_e5m2
 from ml_dtypes._ml_dtypes_ext import float8_e5m2fnuz
+from ml_dtypes._ml_dtypes_ext import float8_p3109_p3
+from ml_dtypes._ml_dtypes_ext import float8_p3109_p4
+from ml_dtypes._ml_dtypes_ext import float8_p3109_p5
+
 import numpy as np
 
 _bfloat16_dtype = np.dtype(bfloat16)
@@ -30,6 +34,9 @@ _float8_e4m3fn_dtype = np.dtype(float8_e4m3fn)
 _float8_e4m3fnuz_dtype = np.dtype(float8_e4m3fnuz)
 _float8_e5m2_dtype = np.dtype(float8_e5m2)
 _float8_e5m2fnuz_dtype = np.dtype(float8_e5m2fnuz)
+_float8_p3109_p3_dtype = np.dtype(float8_p3109_p3)
+_float8_p3109_p4_dtype = np.dtype(float8_p3109_p4)
+_float8_p3109_p5_dtype = np.dtype(float8_p3109_p5)
 
 
 class _Bfloat16MachArLike:
@@ -84,6 +91,29 @@ class _Float8E5m2fnuzMachArLike:
     self.smallest_normal = float8_e5m2fnuz(smallest_normal)
     smallest_subnormal = float.fromhex("0x1p-17")
     self.smallest_subnormal = float8_e5m2fnuz(smallest_subnormal)
+
+
+class _Float8IEEEMachArLike:
+
+  def __init__(self, p):
+    # These are hard-coded in order to independently test against the computed values in the C++ implementation
+    if p == 3:
+      smallest_normal = float.fromhex("0x1p-15")
+      self.smallest_normal = float8_p3109_p3(smallest_normal)
+      smallest_subnormal = float.fromhex("0x1p-17")
+      self.smallest_subnormal = float8_p3109_p3(smallest_subnormal)
+
+    if p == 4:
+      smallest_normal = float.fromhex("0x1p-7")
+      self.smallest_normal = float8_p3109_p4(smallest_normal)
+      smallest_subnormal = float.fromhex("0x1p-10")
+      self.smallest_subnormal = float8_p3109_p4(smallest_subnormal)
+
+    if p == 5:
+      smallest_normal = float.fromhex("0x1p-3")
+      self.smallest_normal = float8_p3109_p5(smallest_normal)
+      smallest_subnormal = float.fromhex("0x1p-7")
+      self.smallest_subnormal = float8_p3109_p5(smallest_subnormal)
 
 
 class finfo(np.finfo):  # pylint: disable=invalid-name,missing-class-docstring
@@ -360,6 +390,114 @@ class finfo(np.finfo):  # pylint: disable=invalid-name,missing-class-docstring
     # pylint: enable=protected-access
     return obj
 
+  @staticmethod
+  def _float8_p3109_p_finfo(p):
+    def float_to_str(f):
+      return "%6.2e" % float(f)
+
+    # pylint: disable=protected-access
+    obj = object.__new__(np.finfo)
+
+    if p == 3:
+      dtype = float8_p3109_p3
+      obj.dtype = _float8_p3109_p3_dtype
+    elif p == 4:
+      dtype = float8_p3109_p4
+      obj.dtype = _float8_p3109_p4_dtype
+    elif p == 5:
+      dtype = float8_p3109_p5
+      obj.dtype = _float8_p3109_p5_dtype
+    else:
+      raise NotImplementedError()
+
+    obj._machar = _Float8IEEEMachArLike(p)
+
+    bias = 2 ** (7 - p)
+    tiny = obj._machar.smallest_normal
+    machep = 1 - p
+    eps = 2.0**machep
+    negep = -p
+    epsneg = 2.0**negep
+    max_ = (1 - 2 ** (1 - p)) * 2**bias  #      1'0000 - 0'0010 = 0'1110
+
+    if p == 3:
+      assert tiny == float.fromhex("0x1p-15")
+      assert eps == float.fromhex("0x1p-2")
+      assert epsneg == float.fromhex("0x1p-3")
+      assert max_ == float.fromhex("0x1.8p15")
+    elif p == 4:
+      assert tiny == float.fromhex("0x1p-7")
+      assert eps == float.fromhex("0x1p-3")
+      assert epsneg == float.fromhex("0x1p-4")
+      assert max_ == float.fromhex("0x1.Cp7")
+    elif p == 5:
+      assert tiny == float.fromhex("0x1p-3")
+      assert eps == float.fromhex("0x1p-4")
+      assert epsneg == float.fromhex("0x1p-5")
+      assert max_ == float.fromhex("0x1.Ep3")
+    else:
+      raise NotImplementedError()
+
+    obj.bits = 8
+
+    # nextafter(1.0, Inf) - 1.0
+    obj.eps = dtype(eps)
+
+    # The exponent that yields eps.
+    obj.machep = machep
+
+    # 1.0 = nextafter(1.0, -Inf)
+    obj.epsneg = dtype(epsneg)
+
+    # The exponent that yields epsneg.
+    obj.negep = negep
+
+    # The largest representable number.
+    obj.max = dtype(max_)
+
+    # The smallest representable number, typically -max.
+    obj.min = dtype(-max_)
+
+    obj.nexp = 8 - p
+    obj.nmant = p - 1
+    obj.iexp = obj.nexp
+    obj.maxexp = bias
+    obj.minexp = 1 - bias
+
+    # The approximate number of decimal digits to which this kind of float is precise.
+    obj.precision = 1 if p < 4 else 2
+
+    # The approximate decimal resolution of this type, i.e., 10**-precision.
+    obj.resolution = dtype(10**-obj.precision)
+
+    if not hasattr(obj, "tiny"):
+      obj.tiny = dtype(tiny)
+    if not hasattr(obj, "smallest_normal"):
+      obj.smallest_normal = obj._machar.smallest_normal
+    obj.smallest_subnormal = obj._machar.smallest_subnormal
+
+    obj._str_tiny = float_to_str(tiny)
+    obj._str_smallest_normal = float_to_str(tiny)
+    obj._str_smallest_subnormal = float_to_str(obj.smallest_subnormal)
+    obj._str_max = float_to_str(max_)
+    obj._str_epsneg = float_to_str(epsneg)
+    obj._str_eps = float_to_str(eps)
+    obj._str_resolution = float_to_str(obj.resolution)
+    # pylint: enable=protected-access
+    return obj
+
+  @staticmethod
+  def _float8_p3109_p3_finfo():
+    return finfo._float8_p3109_p_finfo(3)
+
+  @staticmethod
+  def _float8_p3109_p4_finfo():
+    return finfo._float8_p3109_p_finfo(4)
+
+  @staticmethod
+  def _float8_p3109_p5_finfo():
+    return finfo._float8_p3109_p_finfo(5)
+
   def __new__(cls, dtype):
     if (
         isinstance(dtype, str)
@@ -411,4 +549,14 @@ class finfo(np.finfo):  # pylint: disable=invalid-name,missing-class-docstring
       if _float8_e5m2fnuz_dtype not in cls._finfo_cache:
         cls._finfo_cache[_float8_e5m2fnuz_dtype] = cls._float8_e5m2fnuz_finfo()
       return cls._finfo_cache[_float8_e5m2fnuz_dtype]
+    for type_str, test_dtype, finfo in (
+        ("float8_p3109_p3", _float8_p3109_p3_dtype, cls._float8_p3109_p3_finfo),
+        ("float8_p3109_p4", _float8_p3109_p4_dtype, cls._float8_p3109_p4_finfo),
+        ("float8_p3109_p5", _float8_p3109_p5_dtype, cls._float8_p3109_p5_finfo),
+    ):
+      if isinstance(dtype, str) and dtype == type_str or dtype == test_dtype:
+        if test_dtype not in cls._finfo_cache:
+          cls._finfo_cache[test_dtype] = finfo()
+        return cls._finfo_cache[test_dtype]
+
     return super().__new__(cls, dtype)

--- a/ml_dtypes/_src/dtypes.cc
+++ b/ml_dtypes/_src/dtypes.cc
@@ -148,6 +148,51 @@ struct TypeDescriptor<float8_e5m2fnuz> : CustomFloatType<float8_e5m2fnuz> {
 };
 
 template <>
+struct TypeDescriptor<float8_p3109_p<3>> : CustomFloatType<float8_p3109_p<3>> {
+  typedef float8_p3109_p<3> T;
+  static constexpr bool is_floating = true;
+  static constexpr bool is_integral = false;
+  static constexpr const char* kTypeName = "float8_p3109_p3";
+  static constexpr const char* kQualifiedTypeName = "ml_dtypes.float8_p3109_p4";
+  static constexpr const char* kTpDoc = "float8_p3109_p3 floating-point values";
+  static constexpr char kNpyDescrKind = 'V';
+  // TODO(phawkins): there doesn't seem to be a way of guaranteeing a type
+  // character is unique.
+  static constexpr char kNpyDescrType = 'P';
+  static constexpr char kNpyDescrByteorder = '=';
+};
+
+template <>
+struct TypeDescriptor<float8_p3109_p<4>> : CustomFloatType<float8_p3109_p<4>> {
+  typedef float8_p3109_p<4> T;
+  static constexpr bool is_floating = true;
+  static constexpr bool is_integral = false;
+  static constexpr const char* kTypeName = "float8_p3109_p4";
+  static constexpr const char* kQualifiedTypeName = "ml_dtypes.float8_p3109_p4";
+  static constexpr const char* kTpDoc = "float8_p3109_p4 floating-point values";
+  static constexpr char kNpyDescrKind = 'V';
+  // TODO(phawkins): there doesn't seem to be a way of guaranteeing a type
+  // character is unique.
+  static constexpr char kNpyDescrType = 'Q';
+  static constexpr char kNpyDescrByteorder = '=';
+};
+
+template <>
+struct TypeDescriptor<float8_p3109_p<5>> : CustomFloatType<float8_p3109_p<5>> {
+  typedef float8_p3109_p<5> T;
+  static constexpr bool is_floating = true;
+  static constexpr bool is_integral = false;
+  static constexpr const char* kTypeName = "float8_p3109_p5";
+  static constexpr const char* kQualifiedTypeName = "ml_dtypes.float8_p3109_p5";
+  static constexpr const char* kTpDoc = "float8_p3109_p5 floating-point values";
+  static constexpr char kNpyDescrKind = 'V';
+  // TODO(phawkins): there doesn't seem to be a way of guaranteeing a type
+  // character is unique.
+  static constexpr char kNpyDescrType = 'R';
+  static constexpr char kNpyDescrByteorder = '=';
+};
+
+template <>
 struct TypeDescriptor<int4> : Int4TypeDescriptor<int4> {
   typedef int4 T;
   static constexpr bool is_floating = false;
@@ -251,6 +296,21 @@ bool Initialize() {
           numpy.get(), &float8_e5m2fnuz_already_registered)) {
     return false;
   }
+  bool float8_p3109_p3_already_registered;
+  if (!ml_dtypes::RegisterFloatDtype<float8_p3109_p<3>>(
+          numpy.get(), &float8_p3109_p3_already_registered)) {
+    return false;
+  }
+  bool float8_p3109_p4_already_registered;
+  if (!ml_dtypes::RegisterFloatDtype<float8_p3109_p<4>>(
+          numpy.get(), &float8_p3109_p4_already_registered)) {
+    return false;
+  }
+  bool float8_p3109_p5_already_registered;
+  if (!ml_dtypes::RegisterFloatDtype<float8_p3109_p<5>>(
+          numpy.get(), &float8_p3109_p5_already_registered)) {
+    return false;
+  }
 
   if (!ml_dtypes::RegisterInt4Dtype<int4>(numpy.get())) {
     return false;
@@ -285,6 +345,7 @@ bool Initialize() {
   success &= RegisterTwoWayCustomCast<float8_e4m3b11fnuz, float8_e5m2>();
   success &= RegisterTwoWayCustomCast<bfloat16, float8_e4m3fn>();
   success &= RegisterTwoWayCustomCast<bfloat16, float8_e5m2>();
+
   success &= RegisterTwoWayCustomCast<float8_e4m3fnuz, bfloat16>();
   success &= RegisterTwoWayCustomCast<float8_e5m2fnuz, bfloat16>();
   success &= RegisterTwoWayCustomCast<float8_e4m3fnuz, float8_e4m3b11fnuz>();
@@ -293,6 +354,31 @@ bool Initialize() {
   success &= RegisterTwoWayCustomCast<float8_e5m2fnuz, float8_e4m3fn>();
   success &= RegisterTwoWayCustomCast<float8_e4m3fnuz, float8_e5m2>();
   success &= RegisterTwoWayCustomCast<float8_e5m2fnuz, float8_e5m2>();
+
+  success &= RegisterTwoWayCustomCast<float8_p3109_p<3>, bfloat16>();
+  success &= RegisterTwoWayCustomCast<float8_p3109_p<3>, float8_e4m3b11fnuz>();
+  success &= RegisterTwoWayCustomCast<float8_p3109_p<3>, float8_e4m3fn>();
+  success &= RegisterTwoWayCustomCast<float8_p3109_p<3>, float8_e4m3fnuz>();
+  success &= RegisterTwoWayCustomCast<float8_p3109_p<3>, float8_e5m2>();
+  success &= RegisterTwoWayCustomCast<float8_p3109_p<3>, float8_e5m2fnuz>();
+
+  success &= RegisterTwoWayCustomCast<float8_p3109_p<4>, bfloat16>();
+  success &= RegisterTwoWayCustomCast<float8_p3109_p<4>, float8_e4m3b11fnuz>();
+  success &= RegisterTwoWayCustomCast<float8_p3109_p<4>, float8_e4m3fn>();
+  success &= RegisterTwoWayCustomCast<float8_p3109_p<4>, float8_e4m3fnuz>();
+  success &= RegisterTwoWayCustomCast<float8_p3109_p<4>, float8_e5m2>();
+  success &= RegisterTwoWayCustomCast<float8_p3109_p<4>, float8_e5m2fnuz>();
+  success &= RegisterTwoWayCustomCast<float8_p3109_p<4>, float8_p3109_p<3>>();
+
+  success &= RegisterTwoWayCustomCast<float8_p3109_p<5>, bfloat16>();
+  success &= RegisterTwoWayCustomCast<float8_p3109_p<5>, float8_e4m3b11fnuz>();
+  success &= RegisterTwoWayCustomCast<float8_p3109_p<5>, float8_e4m3fn>();
+  success &= RegisterTwoWayCustomCast<float8_p3109_p<5>, float8_e4m3fnuz>();
+  success &= RegisterTwoWayCustomCast<float8_p3109_p<5>, float8_e5m2>();
+  success &= RegisterTwoWayCustomCast<float8_p3109_p<5>, float8_e5m2fnuz>();
+  success &= RegisterTwoWayCustomCast<float8_p3109_p<5>, float8_p3109_p<3>>();
+  success &= RegisterTwoWayCustomCast<float8_p3109_p<5>, float8_p3109_p<4>>();
+
   return success;
 }
 
@@ -301,6 +387,10 @@ static PyModuleDef module_def = {
     "_ml_dtypes_ext",
 };
 
+typedef float8_p3109_p<3> float8_p3109_p3;
+typedef float8_p3109_p<4> float8_p3109_p4;
+typedef float8_p3109_p<5> float8_p3109_p5;
+
 // TODO(phawkins): PyMODINIT_FUNC handles visibility correctly in Python 3.9+.
 // Just use PyMODINIT_FUNC after dropping Python 3.8 support.
 #if defined(WIN32) || defined(_WIN32)
@@ -308,6 +398,12 @@ static PyModuleDef module_def = {
 #else
 #define EXPORT_SYMBOL __attribute__((visibility("default")))
 #endif
+
+template <class Type> bool py_set(Safe_PyObjectPtr &m, char const *str) {
+  PyObject *type_ptr =
+      reinterpret_cast<PyObject *>(TypeDescriptor<Type>::type_ptr);
+  return PyObject_SetAttrString(m.get(), str, type_ptr) >= 0;
+}
 
 extern "C" EXPORT_SYMBOL PyObject* PyInit__ml_dtypes_ext() {
   Safe_PyObjectPtr m = make_safe(PyModule_Create(&module_def));
@@ -321,50 +417,20 @@ extern "C" EXPORT_SYMBOL PyObject* PyInit__ml_dtypes_ext() {
     return nullptr;
   }
 
-  if (PyObject_SetAttrString(
-          m.get(), "float8_e4m3b11fnuz",
-          reinterpret_cast<PyObject*>(
-              TypeDescriptor<float8_e4m3b11fnuz>::type_ptr)) < 0) {
+  bool ok = (py_set<float8_e4m3b11fnuz>(m, "float8_e4m3b11fnuz") &&
+             py_set<float8_e4m3fn>(m, "float8_e4m3fn") &&
+             py_set<float8_e4m3fnuz>(m, "float8_e4m3fnuz") &&
+             py_set<float8_e5m2>(m, "float8_e5m2") &&
+             py_set<float8_e5m2fnuz>(m, "float8_e5m2fnuz") &&
+             py_set<float8_p3109_p3>(m, "float8_p3109_p3") &&
+             py_set<float8_p3109_p4>(m, "float8_p3109_p4") &&
+             py_set<float8_p3109_p5>(m, "float8_p3109_p5") &&
+             py_set<bfloat16>(m, "bfloat16") &&
+             py_set<int4>(m, "int4") &&
+             py_set<uint4>(m, "uint4"));
+  if (!ok)
     return nullptr;
-  }
-  if (PyObject_SetAttrString(m.get(), "float8_e4m3fn",
-                             reinterpret_cast<PyObject*>(
-                                 TypeDescriptor<float8_e4m3fn>::type_ptr)) <
-      0) {
-    return nullptr;
-  }
-  if (PyObject_SetAttrString(m.get(), "float8_e4m3fnuz",
-                             reinterpret_cast<PyObject*>(
-                                 TypeDescriptor<float8_e4m3fnuz>::type_ptr)) <
-      0) {
-    return nullptr;
-  }
-  if (PyObject_SetAttrString(m.get(), "float8_e5m2",
-                             reinterpret_cast<PyObject*>(
-                                 TypeDescriptor<float8_e5m2>::type_ptr)) < 0) {
-    return nullptr;
-  }
-  if (PyObject_SetAttrString(m.get(), "float8_e5m2fnuz",
-                             reinterpret_cast<PyObject*>(
-                                 TypeDescriptor<float8_e5m2fnuz>::type_ptr)) <
-      0) {
-    return nullptr;
-  }
-  if (PyObject_SetAttrString(m.get(), "bfloat16",
-                             reinterpret_cast<PyObject*>(
-                                 TypeDescriptor<bfloat16>::type_ptr)) < 0) {
-    return nullptr;
-  }
-  if (PyObject_SetAttrString(
-          m.get(), "int4",
-          reinterpret_cast<PyObject*>(TypeDescriptor<int4>::type_ptr)) < 0) {
-    return nullptr;
-  }
-  if (PyObject_SetAttrString(
-          m.get(), "uint4",
-          reinterpret_cast<PyObject*>(TypeDescriptor<uint4>::type_ptr)) < 0) {
-    return nullptr;
-  }
+
   return m.release();
 }
 }  // namespace ml_dtypes

--- a/ml_dtypes/_src/ufuncs.h
+++ b/ml_dtypes/_src/ufuncs.h
@@ -316,7 +316,7 @@ using BitsType = typename GetUnsignedInteger<sizeof(T)>::type;
 
 template <typename T>
 std::pair<BitsType<T>, BitsType<T>> SignAndMagnitude(T x) {
-  // For types that represent NaN by -0, (i.e. *fnuz), abs(x) remains -0 without
+  // For types that represent NaN by -0, (i.e. *fnuz, *p3109), abs(x) remains -0 without
   // flipping the sign. Therefore, we need to explicitly check the
   // most-significant bit.
   constexpr BitsType<T> kSignMask = BitsType<T>(1)
@@ -682,7 +682,7 @@ struct NextAfter {
             : static_cast<BitsType<T>>(1);
     BitsType<T> out_int = from_rep + magnitude_adjustment;
     T out = Eigen::numext::bit_cast<T>(out_int);
-    // Some non-IEEE compatible formats may have a representation for NaN
+    // Some non-IEEE-754 compatible formats may have a representation for NaN
     // instead of -0, ensure we return a zero in such cases.
     if constexpr (!std::numeric_limits<T>::is_iec559) {
       if (Eigen::numext::isnan(out)) {

--- a/ml_dtypes/tests/CMakeLists.txt
+++ b/ml_dtypes/tests/CMakeLists.txt
@@ -1,0 +1,42 @@
+cmake_minimum_required(VERSION 3.14)
+project(my_project)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+set(GOOGLETEST_DOWNLOAD_URL https://github.com/google/googletest/archive/refs/tags/v1.12.0.zip)
+
+include(FetchContent)
+FetchContent_Declare(
+  googletest
+  URL ${GOOGLETEST_DOWNLOAD_URL}
+)
+# For Windows: Prevent overriding the parent project's compiler/linker settings
+set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
+FetchContent_MakeAvailable(googletest)
+
+set(ABSL_PROPAGATE_CXX_STD ON)
+set(ABSL_GOOGLETEST_DOWNLOAD_URL ${GOOGLETEST_DOWNLOAD_URL})
+add_subdirectory(abseil-cpp)
+
+enable_testing()
+
+add_executable(
+  float8_test
+  float8_test.cc
+)
+target_include_directories(float8_test PUBLIC
+  ..
+  ../..
+  ../../third_party/eigen
+)
+
+target_link_libraries(
+  float8_test
+  GTest::gtest_main
+  GTest::gmock_main
+  absl::strings
+)
+
+include(GoogleTest)
+gtest_discover_tests(float8_test)

--- a/ml_dtypes/tests/finfo_test.py
+++ b/ml_dtypes/tests/finfo_test.py
@@ -24,6 +24,9 @@ ALL_DTYPES = [
     ml_dtypes.float8_e4m3fnuz,
     ml_dtypes.float8_e5m2,
     ml_dtypes.float8_e5m2fnuz,
+    ml_dtypes.float8_p3109_p3,
+    ml_dtypes.float8_p3109_p4,
+    ml_dtypes.float8_p3109_p5,
 ]
 
 DTYPES_WITH_NO_INFINITY = [

--- a/ml_dtypes/tests/float8_test.cc
+++ b/ml_dtypes/tests/float8_test.cc
@@ -22,7 +22,7 @@ limitations under the License.
 
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
-#include "third_party/absl/strings/str_cat.h"
+#include "absl/strings/str_cat.h"
 #include "unsupported/Eigen/CXX11/Tensor"
 
 namespace ml_dtypes {
@@ -45,6 +45,12 @@ struct Float8TestParamNames {
       return "float8_e4m3fnuz";
     } else if constexpr (std::is_same_v<TypeParam, float8_e5m2fnuz>) {
       return "float8_e5m2fnuz";
+    } else if constexpr (std::is_same_v<TypeParam, float8_p3109_p<3>>) {
+      return "float8_p3109_p<3>";
+    } else if constexpr (std::is_same_v<TypeParam, float8_p3109_p<4>>) {
+      return "float8_p3109_p<4>";
+    } else if constexpr (std::is_same_v<TypeParam, float8_p3109_p<5>>) {
+      return "float8_p3109_p<5>";
     }
     return absl::StrCat(idx);
   }
@@ -52,7 +58,8 @@ struct Float8TestParamNames {
 
 using Float8Types =
     ::testing::Types<float8_e4m3fn, float8_e5m2, float8_e4m3b11fnuz,
-                     float8_e4m3fnuz, float8_e5m2fnuz>;
+                     float8_e4m3fnuz, float8_e5m2fnuz,
+                     float8_p3109_p<3>, float8_p3109_p<4>, float8_p3109_p<5>>;
 TYPED_TEST_SUITE(Float8Test, Float8Types, Float8TestParamNames);
 
 TEST(Float8E4m3Test, NumericLimits) {
@@ -225,6 +232,106 @@ TEST(Float8E5m2fnuzTest, NumericLimits) {
   EXPECT_EQ(std::numeric_limits<float8_e5m2fnuz>::has_infinity, false);
   EXPECT_EQ(std::numeric_limits<float8_e5m2fnuz>::has_quiet_NaN, true);
   EXPECT_EQ(std::numeric_limits<float8_e5m2fnuz>::has_signaling_NaN, false);
+}
+
+// TODO: Float8E replacements
+TEST(Float8IEEEP3Test, NumericLimits) {
+  EXPECT_TRUE(
+      Eigen::numext::isnan(std::numeric_limits<float8_p3109_p<3>>::quiet_NaN()));
+  EXPECT_TRUE(Eigen::numext::isnan(
+      std::numeric_limits<float8_p3109_p<3>>::signaling_NaN()));
+  EXPECT_EQ(static_cast<float>(std::numeric_limits<float8_p3109_p<3>>::min()),
+            std::exp2(-15));
+  EXPECT_EQ(static_cast<float>(std::numeric_limits<float8_p3109_p<3>>::max()),
+            49152);
+  EXPECT_EQ(static_cast<float>(std::numeric_limits<float8_p3109_p<3>>::lowest()),
+            -49152);
+  EXPECT_EQ(static_cast<float>(std::numeric_limits<float8_p3109_p<3>>::epsilon()),
+            0.25);
+  EXPECT_EQ(
+      static_cast<float>(std::numeric_limits<float8_p3109_p<3>>::round_error()),
+      0.5);
+  EXPECT_TRUE(
+      Eigen::numext::isinf(std::numeric_limits<float8_p3109_p<3>>::infinity()));
+  EXPECT_EQ(
+      static_cast<float>(std::numeric_limits<float8_p3109_p<3>>::denorm_min()),
+      std::exp2(-17));
+  EXPECT_EQ(std::numeric_limits<float8_p3109_p<3>>::digits, 3);
+  EXPECT_EQ(std::numeric_limits<float8_p3109_p<3>>::digits10, 0);
+  EXPECT_EQ(std::numeric_limits<float8_p3109_p<3>>::max_digits10, 2);
+  EXPECT_EQ(std::numeric_limits<float8_p3109_p<3>>::min_exponent, -14);
+  EXPECT_EQ(std::numeric_limits<float8_p3109_p<3>>::min_exponent10, -4);
+  EXPECT_EQ(std::numeric_limits<float8_p3109_p<3>>::max_exponent, 15);
+  EXPECT_EQ(std::numeric_limits<float8_p3109_p<3>>::max_exponent10, 4);
+  EXPECT_EQ(std::numeric_limits<float8_p3109_p<3>>::is_iec559, false);
+  EXPECT_EQ(std::numeric_limits<float8_p3109_p<3>>::has_infinity, true);
+  EXPECT_EQ(std::numeric_limits<float8_p3109_p<3>>::has_signaling_NaN, false);
+}
+
+TEST(Float8IEEEP4Test, NumericLimits) {
+  EXPECT_TRUE(
+      Eigen::numext::isnan(std::numeric_limits<float8_p3109_p<4>>::quiet_NaN()));
+  EXPECT_TRUE(Eigen::numext::isnan(
+      std::numeric_limits<float8_p3109_p<4>>::signaling_NaN()));
+  EXPECT_EQ(static_cast<float>(std::numeric_limits<float8_p3109_p<4>>::min()),
+            std::exp2(-7));
+  EXPECT_EQ(static_cast<float>(std::numeric_limits<float8_p3109_p<4>>::max()),
+            224);
+  EXPECT_EQ(static_cast<float>(std::numeric_limits<float8_p3109_p<4>>::lowest()),
+            -224);
+  EXPECT_EQ(static_cast<float>(std::numeric_limits<float8_p3109_p<4>>::epsilon()),
+            0.125);
+  EXPECT_EQ(
+      static_cast<float>(std::numeric_limits<float8_p3109_p<4>>::round_error()),
+      0.5);
+  EXPECT_TRUE(
+      Eigen::numext::isinf(std::numeric_limits<float8_p3109_p<4>>::infinity()));
+  EXPECT_EQ(
+      static_cast<float>(std::numeric_limits<float8_p3109_p<4>>::denorm_min()),
+      std::exp2(-10));
+  EXPECT_EQ(std::numeric_limits<float8_p3109_p<4>>::digits, 4);
+  EXPECT_EQ(std::numeric_limits<float8_p3109_p<4>>::digits10, 0);
+  EXPECT_EQ(std::numeric_limits<float8_p3109_p<4>>::max_digits10, 3);
+  EXPECT_EQ(std::numeric_limits<float8_p3109_p<4>>::min_exponent, -6);
+  EXPECT_EQ(std::numeric_limits<float8_p3109_p<4>>::min_exponent10, -2);
+  EXPECT_EQ(std::numeric_limits<float8_p3109_p<4>>::max_exponent, 7);
+  EXPECT_EQ(std::numeric_limits<float8_p3109_p<4>>::max_exponent10, 2);
+  EXPECT_EQ(std::numeric_limits<float8_p3109_p<4>>::is_iec559, false);
+  EXPECT_EQ(std::numeric_limits<float8_p3109_p<4>>::has_infinity, true);
+  EXPECT_EQ(std::numeric_limits<float8_p3109_p<4>>::has_signaling_NaN, false);
+}
+
+TEST(Float8IEEEP5Test, NumericLimits) {
+  EXPECT_TRUE(
+      Eigen::numext::isnan(std::numeric_limits<float8_p3109_p<5>>::quiet_NaN()));
+  EXPECT_TRUE(Eigen::numext::isnan(
+      std::numeric_limits<float8_p3109_p<5>>::signaling_NaN()));
+  EXPECT_EQ(static_cast<float>(std::numeric_limits<float8_p3109_p<5>>::min()),
+            std::exp2(-3));
+  EXPECT_EQ(static_cast<float>(std::numeric_limits<float8_p3109_p<5>>::max()),
+            15);
+  EXPECT_EQ(static_cast<float>(std::numeric_limits<float8_p3109_p<5>>::lowest()),
+            -15);
+  EXPECT_EQ(static_cast<float>(std::numeric_limits<float8_p3109_p<5>>::epsilon()),
+            0.0625);
+  EXPECT_EQ(
+      static_cast<float>(std::numeric_limits<float8_p3109_p<5>>::round_error()),
+      0.5);
+  EXPECT_TRUE(
+      Eigen::numext::isinf(std::numeric_limits<float8_p3109_p<5>>::infinity()));
+  EXPECT_EQ(
+      static_cast<float>(std::numeric_limits<float8_p3109_p<5>>::denorm_min()),
+      std::exp2(-7));
+  EXPECT_EQ(std::numeric_limits<float8_p3109_p<5>>::digits, 5);
+  EXPECT_EQ(std::numeric_limits<float8_p3109_p<5>>::digits10, 1);
+  EXPECT_EQ(std::numeric_limits<float8_p3109_p<5>>::max_digits10, 3);
+  EXPECT_EQ(std::numeric_limits<float8_p3109_p<5>>::min_exponent, -2);
+  EXPECT_EQ(std::numeric_limits<float8_p3109_p<5>>::min_exponent10, 0);
+  EXPECT_EQ(std::numeric_limits<float8_p3109_p<5>>::max_exponent, 3);
+  EXPECT_EQ(std::numeric_limits<float8_p3109_p<5>>::max_exponent10, 0);
+  EXPECT_EQ(std::numeric_limits<float8_p3109_p<5>>::is_iec559, false);
+  EXPECT_EQ(std::numeric_limits<float8_p3109_p<5>>::has_infinity, true);
+  EXPECT_EQ(std::numeric_limits<float8_p3109_p<5>>::has_signaling_NaN, false);
 }
 
 TYPED_TEST(Float8Test, FromRep) {
@@ -756,12 +863,18 @@ struct Float8CastTestParamNames {
       std::pair<Type, Eigen::bfloat16>, std::pair<Type, Eigen::half>,      \
       std::pair<Type, float8_e4m3fn>, std::pair<Type, float8_e4m3b11fnuz>, \
       std::pair<Type, float8_e4m3fnuz>, std::pair<Type, float8_e5m2fnuz>,  \
+      std::pair<Type, float8_p3109_p<3>>, \
+      std::pair<Type, float8_p3109_p<4>>, \
+      std::pair<Type, float8_p3109_p<5>>,  \
       std::pair<Type, float8_e5m2>, std::pair<Type, bool>,                 \
       std::pair<Type, int32_t>, std::pair<Type, int64_t>
 
 #define GEN_TYPE_PAIRS()                                             \
   GEN_DEST_TYPES(float8_e4m3fn), GEN_DEST_TYPES(float8_e4m3b11fnuz), \
       GEN_DEST_TYPES(float8_e5m2), GEN_DEST_TYPES(float8_e4m3fnuz),  \
+      GEN_DEST_TYPES(float8_p3109_p<3>), \
+      GEN_DEST_TYPES(float8_p3109_p<4>), \
+      GEN_DEST_TYPES(float8_p3109_p<5>), \
       GEN_DEST_TYPES(float8_e5m2fnuz)
 
 using Float8CastTypePairs = ::testing::Types<GEN_TYPE_PAIRS()>;


### PR DESCRIPTION
Moved to [awf/ml_dtypes](https://github.com/jax-ml/ml_dtypes/pull/122)